### PR TITLE
feat(todos): add POST /todos endpoint

### DIFF
--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -6,4 +6,13 @@ router.get('/', (req, res) => {
   res.json(store.getAll());
 });
 
+router.post('/', (req, res) => {
+  const { title } = req.body;
+  if (!title) {
+    return res.status(400).json({ error: 'title is required' });
+  }
+  const todo = store.create(title);
+  res.status(201).json(todo);
+});
+
 module.exports = router;

--- a/src/todos.js
+++ b/src/todos.js
@@ -5,4 +5,10 @@ function getAll() {
   return todos;
 }
 
-module.exports = { getAll };
+function create(title) {
+  const todo = { id: nextId++, title, completed: false };
+  todos.push(todo);
+  return todo;
+}
+
+module.exports = { getAll, create };

--- a/tests/todos.test.js
+++ b/tests/todos.test.js
@@ -8,3 +8,18 @@ describe('GET /todos', () => {
     expect(Array.isArray(res.body)).toBe(true);
   });
 });
+
+describe('POST /todos', () => {
+  it('creates a todo and returns 201', async () => {
+    const res = await request(app).post('/todos').send({ title: 'Aprender GitHub Actions' });
+    expect(res.status).toBe(201);
+    expect(res.body.title).toBe('Aprender GitHub Actions');
+    expect(res.body.completed).toBe(false);
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('returns 400 if title is missing', async () => {
+    const res = await request(app).post('/todos').send({});
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Agrega endpoint POST /todos para crear nuevas tareas
- Valida que el campo title esté presente, devuelve 400 si falta

## Changes
- src/todos.js — función create() que genera id autoincremental
- src/routes/todos.js — POST /todos con validación de body
- tests/todos.test.js — tests para creación exitosa y body inválido

## Testing
- [x] Tests agregados (2 casos: creación exitosa y title faltante)
- [x] Tests pasan localmente (4 tests en total)

Closes #3