### PR TITLE
feat(todos): add PUT /todos/:id endpoint

### DIFF
--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -15,4 +15,11 @@ router.post('/', (req, res) => {
   res.status(201).json(todo);
 });
 
+router.put('/:id', (req, res) => {
+  const id = parseInt(req.params.id);
+  const todo = store.update(id, req.body);
+  if (!todo) return res.status(404).json({ error: 'todo not found' });
+  res.json(todo);
+});
+
 module.exports = router;

--- a/src/todos.js
+++ b/src/todos.js
@@ -11,4 +11,12 @@ function create(title) {
   return todo;
 }
 
-module.exports = { getAll, create };
+function update(id, fields) {
+  const todo = todos.find(t => t.id === id);
+  if (!todo) return null;
+  if (fields.title !== undefined) todo.title = fields.title;
+  if (fields.completed !== undefined) todo.completed = fields.completed;
+  return todo;
+}
+
+module.exports = { getAll, create, update };

--- a/tests/todos.test.js
+++ b/tests/todos.test.js
@@ -9,6 +9,23 @@ describe('GET /todos', () => {
   });
 });
 
+describe('PUT /todos/:id', () => {
+  it('updates title and completed', async () => {
+    const created = await request(app).post('/todos').send({ title: 'Original' });
+    const id = created.body.id;
+
+    const res = await request(app).put(`/todos/${id}`).send({ title: 'Updated', completed: true });
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Updated');
+    expect(res.body.completed).toBe(true);
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const res = await request(app).put('/todos/9999').send({ title: 'X' });
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('POST /todos', () => {
   it('creates a todo and returns 201', async () => {
     const res = await request(app).post('/todos').send({ title: 'Aprender GitHub Actions' });


### PR DESCRIPTION
## Summary
- Agrega endpoint PUT /todos/:id para actualizar title y/o completed de una tarea
- Devuelve 404 si el id no existe

## Changes
- src/todos.js — función update() que modifica los campos recibidos
- src/routes/todos.js — PUT /todos/:id con parseo de id y manejo de 404
- tests/todos.test.js — 2 casos: actualización exitosa y id inexistente

## Testing
- [x] Tests agregados
- [x] 6 tests pasan localmente

Closes #4