### PR TITLE
feat(todos): add DELETE /todos/:id endpoint

### DIFF
--- a/src/routes/todos.js
+++ b/src/routes/todos.js
@@ -22,4 +22,11 @@ router.put('/:id', (req, res) => {
   res.json(todo);
 });
 
+router.delete('/:id', (req, res) => {
+  const id = parseInt(req.params.id);
+  const deleted = store.remove(id);
+  if (!deleted) return res.status(404).json({ error: 'todo not found' });
+  res.status(204).send();
+});
+
 module.exports = router;

--- a/src/todos.js
+++ b/src/todos.js
@@ -19,4 +19,11 @@ function update(id, fields) {
   return todo;
 }
 
-module.exports = { getAll, create, update };
+function remove(id) {
+  const index = todos.findIndex(t => t.id === id);
+  if (index === -1) return false;
+  todos.splice(index, 1);
+  return true;
+}
+
+module.exports = { getAll, create, update, remove };

--- a/tests/todos.test.js
+++ b/tests/todos.test.js
@@ -9,6 +9,21 @@ describe('GET /todos', () => {
   });
 });
 
+describe('DELETE /todos/:id', () => {
+  it('deletes a todo and returns 204', async () => {
+    const created = await request(app).post('/todos').send({ title: 'To delete' });
+    const id = created.body.id;
+
+    const res = await request(app).delete(`/todos/${id}`);
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const res = await request(app).delete('/todos/9999');
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('PUT /todos/:id', () => {
   it('updates title and completed', async () => {
     const created = await request(app).post('/todos').send({ title: 'Original' });


### PR DESCRIPTION
## Summary
- Agrega endpoint DELETE /todos/:id para eliminar una tarea por ID
- Devuelve 204 sin body si la eliminación fue exitosa, 404 si el id no existe

## Changes
- src/todos.js — función remove() que elimina por índice
- src/routes/todos.js — DELETE /todos/:id con manejo de 404
- tests/todos.test.js — 2 casos: eliminación exitosa e id inexistente

## Testing
- [x] Tests agregados
- [x] 8 tests pasan localmente

Closes #5