### PR TITLE
feat(e2e): add Playwright E2E tests for full CRUD flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,8 @@ jobs:
       - run: npm ci
 
       - run: npm test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - run: npm run test:e2e

--- a/e2e/todos.spec.js
+++ b/e2e/todos.spec.js
@@ -1,0 +1,69 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('TODO API',
+  { tag: ['@critical', '@e2e', '@todos'] },
+  () => {
+    test('full CRUD flow',
+      { tag: ['@TODOS-E2E-001'] },
+      async ({ request }) => {
+        // Crear tarea
+        const created = await request.post('/todos', {
+          data: { title: 'Aprender Playwright' },
+        });
+        expect(created.status()).toBe(201);
+        const todo = await created.json();
+        expect(todo.title).toBe('Aprender Playwright');
+        expect(todo.completed).toBe(false);
+        expect(todo.id).toBeDefined();
+
+        // Verificar que aparece en la lista
+        const list = await request.get('/todos');
+        expect(list.status()).toBe(200);
+        const todos = await list.json();
+        expect(todos.some(t => t.id === todo.id)).toBe(true);
+
+        // Actualizar
+        const updated = await request.put(`/todos/${todo.id}`, {
+          data: { title: 'Playwright dominado', completed: true },
+        });
+        expect(updated.status()).toBe(200);
+        const updatedTodo = await updated.json();
+        expect(updatedTodo.title).toBe('Playwright dominado');
+        expect(updatedTodo.completed).toBe(true);
+
+        // Eliminar
+        const deleted = await request.delete(`/todos/${todo.id}`);
+        expect(deleted.status()).toBe(204);
+
+        // Verificar que ya no está
+        const finalList = await request.get('/todos');
+        const finalTodos = await finalList.json();
+        expect(finalTodos.some(t => t.id === todo.id)).toBe(false);
+      }
+    );
+
+    test('POST /todos returns 400 when title is missing',
+      { tag: ['@TODOS-E2E-002'] },
+      async ({ request }) => {
+        const res = await request.post('/todos', { data: {} });
+        expect(res.status()).toBe(400);
+      }
+    );
+
+    test('PUT /todos/:id returns 404 for non-existent id',
+      { tag: ['@TODOS-E2E-003'] },
+      async ({ request }) => {
+        const res = await request.put('/todos/9999', { data: { title: 'X' } });
+        expect(res.status()).toBe(404);
+      }
+    );
+
+    test('DELETE /todos/:id returns 404 for non-existent id',
+      { tag: ['@TODOS-E2E-004'] },
+      async ({ request }) => {
+        const res = await request.delete('/todos/9999');
+        expect(res.status()).toBe(404);
+      }
+    );
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^5.2.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "jest": "^30.3.0",
         "supertest": "^7.2.2"
       }
@@ -1039,6 +1040,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4276,6 +4293,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/server.js",
-    "test": "jest",
+    "test": "jest --testPathPatterns=tests/",
     "test:e2e": "playwright test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/server.js",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
     "express": "^5.2.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "jest": "^30.3.0",
     "supertest": "^7.2.2"
   }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'node src/server.js',
+    url: 'http://localhost:3000/todos',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- Agrega tests E2E con Playwright que prueban el flujo completo de la API contra el servidor real
- El CI ahora corre Jest (integración) y Playwright (E2E) en cada PR

## Changes
- e2e/todos.spec.js — 4 tests: flujo CRUD completo + casos de error por endpoint
- playwright.config.js — levanta el servidor automáticamente antes de correr los tests
- .github/workflows/ci.yml — agrega paso de instalación de browsers y ejecución de E2E
- package.json — agrega script test:e2e

## Testing
- [x] 4 tests E2E pasan localmente
- [x] GGA review: PASSED

Closes #14